### PR TITLE
remote noUpfront for 3 year resv term

### DIFF
--- a/awspricingfull.py
+++ b/awspricingfull.py
@@ -1735,10 +1735,6 @@ class RDSPrices(AWSPrices):
                                                                                }
                                                              },
                                                       "3" : {
-                                                             "noUpfront" : {
-                                                                            "hourly" : None,
-                                                                            "upfront" : None
-                                                                            },
                                                              "partialUpfront":{
                                                                                "hourly" : None,
                                                                                "upfront" : None
@@ -2221,10 +2217,6 @@ class RSPrices(AWSPrices):
                                                                                }
                                                              },
                                                       "3" : {
-                                                             "noUpfront" : {
-                                                                            "hourly" : None,
-                                                                            "upfront" : None
-                                                                            },
                                                              "partialUpfront":{
                                                                                "hourly" : None,
                                                                                "upfront" : None

--- a/awspricingfull.py
+++ b/awspricingfull.py
@@ -418,10 +418,6 @@ class EC2Prices(AWSPrices):
                                                                                }
                                                              },
                                                       "3" : {
-                                                             "noUpfront" : {
-                                                                            "hourly" : None,
-                                                                            "upfront" : None
-                                                                            },
                                                              "partialUpfront":{
                                                                                "hourly" : None,
                                                                                "upfront" : None


### PR DESCRIPTION
The noUpfront option for 3 year reservation term does not exist.  As a result, the csv file had a bunch of lines which were invalid.  For instance, 

reserved,ec2,us-east-1,t2.micro,,,,linux,heavy,3,noUpfront,,
reserved,ec2,us-east-1,t2.small,,,,linux,heavy,3,noUpfront,,

This change removes generation of those lines.
